### PR TITLE
Closes #23

### DIFF
--- a/suspect/processing/denoising.py
+++ b/suspect/processing/denoising.py
@@ -34,7 +34,7 @@ def sliding_window(input_signal, window_width):
     window /= numpy.sum(window)
     # pad the signal to cover half the window width on each side
     padded_input = _pad(input_signal, len(input_signal) + window_width - 1)
-    result = numpy.zeros(len(input_signal))
+    result = numpy.zeros(len(input_signal), input_signal.dtype)
     for i in range(len(input_signal)):
         result[i] = numpy.dot(window, padded_input[i:(i + window_width)])
     return result
@@ -62,7 +62,7 @@ def sift(input_signal, threshold):
 def svd(input_signal, rank):
     matrix_width = int(len(input_signal) / 2)
     matrix_height = len(input_signal) - matrix_width + 1
-    hankel_matrix = numpy.zeros((matrix_width, matrix_height))
+    hankel_matrix = numpy.zeros((matrix_width, matrix_height), input_signal.dtype)
     for i in range(matrix_height):
         hankel_matrix[:, i] = input_signal[i:(i + matrix_width)]
     # perform the singular value decomposition

--- a/suspect/processing/denoising.py
+++ b/suspect/processing/denoising.py
@@ -34,7 +34,7 @@ def sliding_window(input_signal, window_width):
     window /= numpy.sum(window)
     # pad the signal to cover half the window width on each side
     padded_input = _pad(input_signal, len(input_signal) + window_width - 1)
-    result = numpy.zeros(len(input_signal), input_signal.dtype)
+    result = numpy.zeros_like(input_signal)
     for i in range(len(input_signal)):
         result[i] = numpy.dot(window, padded_input[i:(i + window_width)])
     return result

--- a/tests/test_mrs/test_processing.py
+++ b/tests/test_mrs/test_processing.py
@@ -1,8 +1,9 @@
 import suspect
 
 import numpy
-import pytest
 import warnings
+
+warnings.filterwarnings('error')
 
 
 def test_null_transform():
@@ -84,36 +85,21 @@ def test_gaussian_denoising():
 
 
 def test_svd_dtype():
-    warnings.filterwarnings('error')
-    try:
-        data = numpy.ones(128, dtype=complex)
-        denoised_data = suspect.processing.denoising.svd(data, 8)
-        assert data.dtype == denoised_data.dtype
-
-    except numpy.core.numeric.ComplexWarning:
-        raise
+    data = numpy.ones(128, dtype=complex)
+    denoised_data = suspect.processing.denoising.svd(data, 8)
+    assert data.dtype == denoised_data.dtype
 
 
 def test_sliding_window_dtype():
-    warnings.filterwarnings('error')
-    try:
-        data = numpy.ones(128, dtype=complex)
-        denoised_data = suspect.processing.denoising.sliding_window(data, 30)
-        assert data.dtype == denoised_data.dtype
-
-    except numpy.core.numeric.ComplexWarning:
-        raise
+    data = numpy.ones(128, dtype=complex)
+    denoised_data = suspect.processing.denoising.sliding_window(data, 30)
+    assert data.dtype == denoised_data.dtype
 
 
 def test_sliding_gaussian_dtype():
-    warnings.filterwarnings('error')
-    try:
-        data = numpy.ones(128, dtype=complex)
-        denoised_data = suspect.processing.denoising.sliding_gaussian(data, 30)
-        assert data.dtype == denoised_data.dtype
-
-    except numpy.core.numeric.ComplexWarning:
-        raise
+    data = numpy.ones(128, dtype=complex)
+    denoised_data = suspect.processing.denoising.sliding_gaussian(data, 30)
+    assert data.dtype == denoised_data.dtype
 
 
 def test_water_suppression():

--- a/tests/test_mrs/test_processing.py
+++ b/tests/test_mrs/test_processing.py
@@ -1,6 +1,8 @@
 import suspect
 
 import numpy
+import pytest
+import warnings
 
 
 def test_null_transform():
@@ -79,6 +81,39 @@ def test_gaussian_denoising():
     data = numpy.ones(128)
     denoised_data = suspect.processing.denoising.sliding_gaussian(data, 11)
     numpy.testing.assert_almost_equal(data, denoised_data)
+
+
+def test_svd_dtype():
+    warnings.filterwarnings('error')
+    try:
+        data = numpy.ones(128, dtype=complex)
+        denoised_data = suspect.processing.denoising.svd(data, 8)
+        assert data.dtype == denoised_data.dtype
+
+    except numpy.core.numeric.ComplexWarning:
+        raise
+
+
+def test_sliding_window_dtype():
+    warnings.filterwarnings('error')
+    try:
+        data = numpy.ones(128, dtype=complex)
+        denoised_data = suspect.processing.denoising.sliding_window(data, 30)
+        assert data.dtype == denoised_data.dtype
+
+    except numpy.core.numeric.ComplexWarning:
+        raise
+
+
+def test_sliding_gaussian_dtype():
+    warnings.filterwarnings('error')
+    try:
+        data = numpy.ones(128, dtype=complex)
+        denoised_data = suspect.processing.denoising.sliding_gaussian(data, 30)
+        assert data.dtype == denoised_data.dtype
+
+    except numpy.core.numeric.ComplexWarning:
+        raise
 
 
 def test_water_suppression():


### PR DESCRIPTION
Changed the sliding_window and svd methods in suspect.processing.denoising to retain the data type of the input signal when denoising.
 Added tests in tests.test_mrs.test_processing to ensure that the denoising methods retain the input signal data type. ComplexWarning is raised as an error if not.