### PR TITLE
Use common phase adjust function when fitting #31

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ setuptools>=26.0
 sphinx>=1.4
 nbsphinx
 ipykernel
+numpy
+lmfit


### PR DESCRIPTION
Modified the fit function in singlet.py to use the adjust_phase() function from the suspect API instead of implementing its own function. Deleted the phase_fid() function because it's redundant now. Closes #31
Fixed some formatting in singlet.py that was causing PEP8 warnings
Modified the project requirements to include numpy and lmfit