### PR TITLE
ENH: ImageBase transforms can apply to arrays of coords

### DIFF
--- a/suspect/_transforms.py
+++ b/suspect/_transforms.py
@@ -68,3 +68,37 @@ def rotation_matrix(angle, axis):
     matrix[2, 1] = axis[2] * axis[1] * (1 - c) + axis[0] * s
     matrix[2, 2] = c + axis[2] ** 2 * (1 - c)
     return matrix
+
+
+def normalise_positions_for_transform(*args):
+    """
+    Takes an input set of arguments which should represent some (x, y, z)
+    coords to be transformed and makes sure they are in a numpy.ndarray,
+    and adds a w dimension of magnitude 1.
+    
+    The two acceptable forms of input arguments are a single array_like
+    with final dimension of 3, or three floating point arguments representing
+    x, y and z. In the first case the returned array will have the same shape
+    for all axes except the last, which will go from size 3 to 4, while in the
+    second case the returned array will be of shape (4,).
+    
+    Parameters
+    ----------
+    args : array_like or 3 separate floats
+        The arguments to be processed
+    
+    Returns
+    -------
+    numpy.ndarray
+        Points ready for transformation by a matrix
+    """
+    if len(args) == 3:
+        positions = [*args, 1]
+    elif len(args) == 1:
+        positions = numpy.atleast_2d(args[0])
+        w_array = numpy.expand_dims(numpy.ones(positions.shape[:-1]), axis=-1)
+        positions = numpy.append(positions, w_array, axis=-1)
+    else:
+        raise ValueError("Unrecognised form for input args")
+
+    return positions

--- a/tests/test_mrs/test_base.py
+++ b/tests/test_mrs/test_base.py
@@ -1,6 +1,8 @@
 import suspect
 import numpy
+import pytest
 import suspect.base
+from suspect import _transforms
 
 
 def test_create_base():
@@ -12,9 +14,29 @@ def test_create_base():
 
 
 def test_base_transform():
-    position = [10, 20, 30]
-    voxel_size = [20, 20, 20]
+    position = numpy.array([10, 20, 30])
+    voxel_size = numpy.array([20, 20, 20])
     transform = suspect.transformation_matrix([1, 0, 0], [0, 1, 0], position, voxel_size)
     base = suspect.base.ImageBase(numpy.zeros(1), transform)
     numpy.testing.assert_equal(base.position, position)
     numpy.testing.assert_equal(base.voxel_size, voxel_size)
+    transformed = base.to_scanner(0, 0, 0)
+    numpy.testing.assert_equal(transformed, position)
+    transformed = base.to_scanner(numpy.array([[0, 0, 0], [1, 1, 1]]))
+    numpy.testing.assert_equal(transformed, [position, position + voxel_size])
+    transformed = base.from_scanner(position)
+    numpy.testing.assert_equal((0, 0, 0), transformed)
+
+
+def test_transforms_fail():
+    base = suspect.base.ImageBase(numpy.zeros(1))
+    with pytest.raises(ValueError):
+        base.to_scanner(0, 0, 0)
+    with pytest.raises(ValueError):
+        base.from_scanner(0, 0, 0)
+    with pytest.raises(ValueError):
+        pos = base.position
+    with pytest.raises(ValueError):
+        vox = base.voxel_size
+    with pytest.raises(ValueError):
+        _transforms.normalise_positions_for_transform(0, 0)


### PR DESCRIPTION
The `ImageBase.from_scanner()`/`to_scanner()` functions now accept
`numpy.ndarray`s of coordinates as well as simple x, y, z arguments.

Fixes #63