### PR TITLE
ENH: create_mask() function for voxel on reference image

### DIFF
--- a/suspect/image/__init__.py
+++ b/suspect/image/__init__.py
@@ -1,1 +1,2 @@
 from suspect.image._image import *
+from ._mask import create_mask

--- a/suspect/image/_mask.py
+++ b/suspect/image/_mask.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+
+def create_mask(source_image, ref_image, voxels=None):
+    """
+    Creates a volumetric mask for the source_image voxel in the coordinate
+    system of the ref_image volume.
+    
+    Parameters
+    ----------
+    source_image : MRSBase
+        The spectroscopy volume from which to create the mask.
+    ref_image : ImageBase
+        The reference image volume which defines the coordinate system for
+        the mask.
+    
+    Returns
+    -------
+    numpy.ndarray
+        Boolean array with the same shape as ref_image, True for all voxels
+        inside source_image, false for all others.
+    """
+
+    # create a grid of coordinates for all points in the ref_image
+    # the ref_image has coord index order [z, y, x] so we reverse the shape
+    # to get the indices in (x, y, z) format for the coordinate conversion
+    ref_coords = np.mgrid[[range(0, size) for size in ref_image.shape[::-1]]]
+
+    # mgrid puts the (x, y, z) tuple at the front, we want it at the back
+    ref_coords = np.moveaxis(ref_coords, 0, -1)
+
+    # now we can apply to_scanner and from_scanner to convert from ref coords
+    # into source coords
+    scanner_coords = ref_image.to_scanner(ref_coords)
+    source_coords = source_image.from_scanner(scanner_coords)
+
+    # now check whether the source_coords are in the selected voxel
+    # TODO for now, we assume single voxel data until issue 50 is resolved
+
+    # have to transpose the result to get it to match the shape of ref_image
+    return np.all((source_coords[..., 0] < 0.5,
+                   source_coords[..., 0] >= -0.5,
+                   source_coords[..., 1] >= -0.5,
+                   source_coords[..., 2] >= -0.5,
+                   source_coords[..., 1] < 0.5,
+                   source_coords[..., 2] < 0.5), axis=0).T

--- a/tests/test_mrs/test_image.py
+++ b/tests/test_mrs/test_image.py
@@ -1,0 +1,23 @@
+import suspect
+
+import suspect._transforms
+
+import numpy as np
+
+
+def test_simple_mask():
+    source_transform = suspect._transforms.transformation_matrix([1, 0, 0],
+                                                                 [0, 1, 0],
+                                                                 [5, 0, 0],
+                                                                 [10, 10, 10])
+    ref_transform = suspect._transforms.transformation_matrix([1, 0, 0],
+                                                              [0, 1, 0],
+                                                              [-10, -5, -5],
+                                                              [1, 1, 1])
+    source_volume = suspect.MRSBase(np.ones(1024), 1e-3, 123, transform=source_transform)
+    ref_volume = suspect.base.ImageBase(np.zeros((20, 20, 20)), transform=ref_transform)
+    mask = suspect.image.create_mask(source_volume, ref_volume)
+    assert ref_volume.shape == mask.shape
+    mask_target = np.zeros_like(ref_volume)
+    mask_target[0:10, 0:10, 10:20] = 1
+    np.testing.assert_equal(mask_target.astype('bool'), mask)


### PR DESCRIPTION
Added new create_mask() function to image submodule, which creates a
volumetric mask of a spectroscopy voxel on a reference image volume.

Partially fixes #62. For now this only works with single voxel data,
until #50 is fixed to allow reliable information about the number of
voxels.