### PR TITLE
BUG: image.create_mask now returns ImageBase

### DIFF
--- a/suspect/base.py
+++ b/suspect/base.py
@@ -11,7 +11,8 @@ class ImageBase(numpy.ndarray):
         # input_array is an already formed ndarray
         # we want to make it our class type
         obj = numpy.asarray(input_array).view(cls)
-        obj.transform = transform
+        if transform is not None:
+            obj.transform = transform.copy()
         return obj
 
     def __array_finalize__(self, obj):

--- a/suspect/image/_mask.py
+++ b/suspect/image/_mask.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from ..base import ImageBase
+
 
 def create_mask(source_image, ref_image, voxels=None):
     """
@@ -38,9 +40,11 @@ def create_mask(source_image, ref_image, voxels=None):
     # TODO for now, we assume single voxel data until issue 50 is resolved
 
     # have to transpose the result to get it to match the shape of ref_image
-    return np.all((source_coords[..., 0] < 0.5,
-                   source_coords[..., 0] >= -0.5,
-                   source_coords[..., 1] >= -0.5,
-                   source_coords[..., 2] >= -0.5,
-                   source_coords[..., 1] < 0.5,
-                   source_coords[..., 2] < 0.5), axis=0).T
+    mask_volume = np.all((source_coords[..., 0] < 0.5,
+                          source_coords[..., 0] >= -0.5,
+                          source_coords[..., 1] >= -0.5,
+                          source_coords[..., 2] >= -0.5,
+                          source_coords[..., 1] < 0.5,
+                          source_coords[..., 2] < 0.5), axis=0).T
+
+    return ImageBase(mask_volume, ref_image.transform)


### PR DESCRIPTION
The image.create_mask() function now returns an ImageBase rather than
a bare ndarray, so that it can be more easily saved with the transform
etc. In addition, the ImageBase class is modified to always copy the
transform during initialisation, to avoid accidentally overwriting the
transforms for parents during any modification.