### PR TITLE
ENH: save and load to Nifti files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
             'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
         ],
-        install_requires=['pywavelets', 'scipy', 'numpy', 'lmfit', 'pydicom', 'parsley', 'parse'],
+        install_requires=['pywavelets', 'scipy', 'numpy', 'lmfit', 'pydicom', 'parsley', 'parse', 'nibabel'],
         test_requires=['pytest', 'mock']
 )

--- a/tests/test_mrs/test_image.py
+++ b/tests/test_mrs/test_image.py
@@ -3,6 +3,7 @@ import suspect
 import suspect._transforms
 
 import numpy as np
+import os
 
 
 def test_simple_mask():
@@ -26,6 +27,7 @@ def test_simple_mask():
 def test_nifti_io():
     dicom_volume = suspect.image.load_dicom_volume("tests/test_data/siemens/mri/T1.0001.IMA")
     # save in a temporary nifti file
+    os.makedirs("tests/test_data/tmp", exist_ok=True)
     suspect.image.save_nifti("tests/test_data/tmp/nifti.nii", dicom_volume)
     nifti_volume = suspect.image.load_nifti("tests/test_data/tmp/nifti.nii")
     np.testing.assert_equal(dicom_volume, nifti_volume)

--- a/tests/test_mrs/test_image.py
+++ b/tests/test_mrs/test_image.py
@@ -21,3 +21,12 @@ def test_simple_mask():
     mask_target = np.zeros_like(ref_volume)
     mask_target[0:10, 0:10, 10:20] = 1
     np.testing.assert_equal(mask_target.astype('bool'), mask)
+
+
+def test_nifti_io():
+    dicom_volume = suspect.image.load_dicom_volume("tests/test_data/siemens/mri/T1.0001.IMA")
+    # save in a temporary nifti file
+    suspect.image.save_nifti("tests/test_data/tmp/nifti.nii", dicom_volume)
+    nifti_volume = suspect.image.load_nifti("tests/test_data/tmp/nifti.nii")
+    np.testing.assert_equal(dicom_volume, nifti_volume)
+    np.testing.assert_allclose(dicom_volume.transform, nifti_volume.transform)


### PR DESCRIPTION
Added functions to read and write ImageBase objects to the nifti file
format. Uses nibabel to handle actual disk operations. Note that the
coordinate system used by suspect is the DICOM system, Nifti files
are converted at save/load to this system.