### PR TITLE
BUG: Fixes for resample()

### DIFF
--- a/suspect/base.py
+++ b/suspect/base.py
@@ -122,12 +122,12 @@ class ImageBase(np.ndarray):
     @property
     @requires_transform
     def row_vector(self):
-        return self.transform[:3, 1] / np.linalg.norm(self.transform[:3, 1])
+        return self.transform[:3, 0] / np.linalg.norm(self.transform[:3, 0])
 
     @property
     @requires_transform
     def col_vector(self):
-        return self.transform[:3, 0] / np.linalg.norm(self.transform[:3, 0])
+        return self.transform[:3, 1] / np.linalg.norm(self.transform[:3, 1])
 
     @requires_transform
     def _closest_axis(self, target_axis):
@@ -264,12 +264,13 @@ class ImageBase(np.ndarray):
                        + JJ[..., np.newaxis] * col_vector \
                        + KK[..., np.newaxis] * slice_vector + centre
 
+        image_coords = self.from_scanner(space_coords).reshape(*space_coords.shape)[..., ::-1].astype(np.int)
         resampled = scipy.interpolate.interpn([np.arange(dim) for dim in self.shape],
                                               self,
-                                              self.from_scanner(space_coords)[..., ::-1],
+                                              image_coords,
                                               method=method,
                                               bounds_error=False,
-                                              fill_value=0)
+                                              fill_value=0).squeeze()
 
         transform = _transforms.transformation_matrix(row_vector,
                                                       col_vector,

--- a/tests/test_mrs/test_base.py
+++ b/tests/test_mrs/test_base.py
@@ -55,8 +55,8 @@ def test_find_axes():
                                                   [1, 1, 1])
     base = suspect.base.ImageBase(np.zeros(1), transform=transform)
     np.testing.assert_equal(base.axial_vector, base.slice_vector)
-    np.testing.assert_equal(base.coronal_vector, base.row_vector)
-    np.testing.assert_equal(base.sagittal_vector, base.col_vector)
+    np.testing.assert_equal(base.coronal_vector, base.col_vector)
+    np.testing.assert_equal(base.sagittal_vector, base.row_vector)
 
 
 def test_find_axes_reversed():
@@ -66,8 +66,8 @@ def test_find_axes_reversed():
                                                   [1, 1, 1])
     base = suspect.base.ImageBase(np.zeros(1), transform=transform)
     np.testing.assert_equal(base.axial_vector, base.slice_vector)
-    np.testing.assert_equal(base.coronal_vector, -base.row_vector)
-    np.testing.assert_equal(base.sagittal_vector, -base.col_vector)
+    np.testing.assert_equal(base.coronal_vector, -base.col_vector)
+    np.testing.assert_equal(base.sagittal_vector, -base.row_vector)
 
 
 def test_centre():

--- a/tests/test_mrs/test_image.py
+++ b/tests/test_mrs/test_image.py
@@ -32,3 +32,13 @@ def test_nifti_io():
     nifti_volume = suspect.image.load_nifti("tests/test_data/tmp/nifti.nii")
     np.testing.assert_equal(dicom_volume, nifti_volume)
     np.testing.assert_allclose(dicom_volume.transform, nifti_volume.transform)
+
+
+def test_resample_single_slice():
+    source_volume = suspect.base.ImageBase(np.random.random((20, 20, 20)), transform=np.eye(4))
+    slc = source_volume.resample(source_volume.row_vector,
+                                 source_volume.col_vector,
+                                 [1, 20, 10],
+                                 centre=(5, 10, 0))
+    assert slc.shape == (20, 10)
+    np.testing.assert_equal(source_volume[0, :, :10], slc)


### PR DESCRIPTION
Previously sample had some issues where using a single slice for the
output shape would cause the slice dimension to be dropped when
transforming the coordinates which would interfere with doing the
interpolation. This is fixed by coercing the transformed coordinates
back into the target output shape.

In addition this brought to light another bug where the row_vector() and
col_vector() functions where swapped, which led to some transposement
problems.

Fixes #90
Fixes #92