### PR TITLE
BUG: load_twix fails on anonymised frame of reference

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+* :bug:`102` fixed problem with loading anonymized twix files
+* :bug:`100` improved loading of Philips sdat files
 * :bug:`98` fixed an issue where 2D images could not be used to create a voxel mask
 * :release:`0.3.6 <02/11/17>`
 * :feature:`94` loading Siemens DICOM now includes a voxel transform

--- a/suspect/io/twix.py
+++ b/suspect/io/twix.py
@@ -91,9 +91,13 @@ def parse_twix_header(header_string):
     patient_birthday = re.search(r"(<ParamString.\"PatientBirthDay\">  { \")(.+)(\"  }\n)", header_string).group(2)
     # get the FrameOfReference to get the date and time of the scan
     frame_of_reference = re.search(r"(<ParamString.\"FrameOfReference\">  { )(\".+\")(  }\n)", header_string).group(2)
-    exam_date_time = frame_of_reference.split(".")[10]
-    exam_date = exam_date_time[2:8]
-    exam_time = exam_date_time[8:14]
+    if re.match("x*", frame_of_reference):
+        exam_date = "x" * 6
+        exam_time = "x" * 6
+    else:
+        exam_date_time = frame_of_reference.split(".")[10]
+        exam_date = exam_date_time[2:8]
+        exam_time = exam_date_time[8:14]
     # get the scan parameters
     frequency_matches = [
         r"<ParamLong.\"Frequency\">  { \d*  }",


### PR DESCRIPTION
load_twix now checks to see if the frame of reference is anonymised
before trying to extract information from it