### PR TITLE
ENH: singlet fitting returns MRSData of fit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :enh:`87` singlet fitting returns MRSData for fit
 * :bug:`102` fixed problem with loading anonymized twix files
 * :bug:`100` improved loading of Philips sdat files
 * :bug:`98` fixed an issue where 2D images could not be used to create a voxel mask

--- a/suspect/fitting/singlet.py
+++ b/suspect/fitting/singlet.py
@@ -192,7 +192,7 @@ def fit(fid, model, baseline_points=16):
         -------
         fitting_weights : list
             Tuple of weights
-        fitted_data : list
+        fitted_data : MRSData
             Fitted data
         fitting_result : lmfit MinimizerResult instance
 
@@ -203,7 +203,7 @@ def fit(fid, model, baseline_points=16):
                                         xtol=5e-3)
 
         real_fitted_data, fitting_weights = do_fit(fitting_result.params, data.time_axis(), unphase(data, fitting_result.params))
-        fitted_data = real_to_complex(real_fitted_data)
+        fitted_data = data.inherit(real_to_complex(real_fitted_data))
 
         return fitting_weights, fitted_data, fitting_result
 

--- a/tests/test_mrs/test_fitting.py
+++ b/tests/test_mrs/test_fitting.py
@@ -51,6 +51,8 @@ def test_gaussian(fixed_fid):
 
     numpy.testing.assert_allclose(fitting_result["fit"], fixed_fid, atol=0.001)
 
+    assert(isinstance(fitting_result["fit"], MRSData))
+
 
 def test_bad_param(fixed_fid):
 


### PR DESCRIPTION
To make it easier to e.g. construct frequency axes, take fft
etc. the singlet fitting routine now returns an MRSData object
instead of a bare ndarray.