### PR TITLE
BUG: Loading DICOM files with non-Siemens extensions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :bug:`125` loading DICOM image volumes uses supplied extension to identify candidate slices
 * :feature:`124` GE P-files are now supported
 * :bug:`121` fixed missing return of MRSData.fid method
 * :release:`0.3.9 <10/07/18>`


### PR DESCRIPTION
This commit changes the way DICOM files are loaded into a
volume, instead of looking for .ima or .dcm files, the
extension from the supplied slice is used to identify
other potential slices.