### PR TITLE
ENH: Add TR to MRSBase objects

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :feature:`135` added TR parameter to MRSBase objects
 * :feature:`133` improved interface to frequency correction methods and new method RATS
 * :release:`0.4.0 <13/05/20>`
 * :feature:`128` channel combination functions can now accept a channel axis

--- a/suspect/image/_image.py
+++ b/suspect/image/_image.py
@@ -109,7 +109,7 @@ def load_nifti(filename):
     nii = nibabel.load(filename)
 
     # nibabel loads cols, rows, slices, so we transpose to match DICOM
-    image = suspect.base.ImageBase(nii.get_data().T, nii.affine)
+    image = suspect.base.ImageBase(nii.get_fdata().T, nii.affine)
 
     # nifti also uses a reversed coordinate system for x and y, so negate them
     image.transform[:2] *= -1.0

--- a/suspect/io/ge.py
+++ b/suspect/io/ge.py
@@ -1,4 +1,4 @@
-from suspect import MRSData, transformation_matrix, rotation_matrix
+from suspect import MRSData, transformation_matrix
 
 import functools
 import numpy
@@ -10,8 +10,8 @@ except ModuleNotFoundError as e:
 
 
 gerecon_err_msg = "GE P-file functionality requires the GE \"Orchestra for " \
-"Python\" package to be installed. For more information, please visit " \
-"http://suspect.readthedocs.io/en/latest/pfiles.html"
+  "Python\" package to be installed. For more information, please visit " \
+  "http://suspect.readthedocs.io/en/latest/pfiles.html"
 
 
 def requires_gerecon(func):
@@ -42,6 +42,7 @@ def extract_header_parameters(header):
     dt = 1 / header["rdb_hdr_rec"]["spectral_width"]
     f0 = header["rdb_hdr_ps"]["mps_freq"] * 1e-7
     te = header["rdb_hdr_rec"]["rdb_hdr_te"] / 1000  # convert from us to ms
+    tr = header["rdb_hdr_image"]["tr"] / 1000  # convert from us to ms
 
     # calculating the transform is quite involved
     # GE internally uses a RAS coordinate system, so we have to convert to the
@@ -78,6 +79,7 @@ def extract_header_parameters(header):
         "dt": dt,
         "f0": f0,
         "te": te,
+        "tr": tr,
         "transform": transform
     }
 

--- a/suspect/io/philips.py
+++ b/suspect/io/philips.py
@@ -66,7 +66,8 @@ def load_sdat(sdat_filename, spar_filename=None, spar_encoding=None):
     return MRSData(raw_data,
                    dt,
                    parameter_dict["synthesizer_frequency"] * 1e-6,
-                   te=parameter_dict["echo_time"])
+                   te=parameter_dict["echo_time"],
+                   tr=parameter_dict["repetition_time"])
 
 
 def _vax_to_ieee_single_float(data):

--- a/suspect/io/rda.py
+++ b/suspect/io/rda.py
@@ -49,7 +49,7 @@ def load_rda(filename):
                 header_dict[key] = float(value)
             elif "[" in key and "]" in key:
                 # could be a dict or a list
-                key, index = re.split("\]|\[", key)[0:2]
+                key, index = re.split(r"\]|\[", key)[0:2]
                 if key in rda_types["dictionaries"]:
                     if key not in header_dict:
                         header_dict[key] = {}
@@ -121,5 +121,6 @@ def load_rda(filename):
                    header_dict["DwellTime"] * 1e-6,
                    header_dict["MRFrequency"],
                    te=header_dict["TE"],
+                   tr=header_dict["TR"],
                    transform=to_scanner,
                    metadata=metadata)

--- a/suspect/io/siemens.py
+++ b/suspect/io/siemens.py
@@ -177,6 +177,7 @@ def load_siemens_dicom(filename):
                    csa_header["RealDwellTime"] * 1e-9,
                    csa_header["ImagingFrequency"],
                    te=csa_header["EchoTime"],
+                   tr=csa_header["RepetitionTime"],
                    transform=transform,
                    metadata=metadata)
 

--- a/suspect/io/twix.py
+++ b/suspect/io/twix.py
@@ -65,6 +65,7 @@ class TwixBuilder(object):
                            self.header_params["dt"],
                            self.header_params["f0"],
                            te=self.header_params["te"],
+                           tr=self.header_params["tr"],
                            metadata=metadata,
                            transform=self.header_params["transform"])
 
@@ -129,6 +130,8 @@ def parse_twix_header(header_string):
     # get TE
     # TE is stored in us, we would prefer to use ms
     te = float(re.search(r"(alTE\[0\]\s*=\s*)(\d+)", header_string).group(2)) / 1000
+    # get TR
+    tr = float(re.search(r"(alTR\[0\]\s*=\s*)(\d+)", header_string).group(2)) / 1000
 
     # get voxel size
     ro_fov = read_double("VoI_RoFOV", header_string)
@@ -173,6 +176,7 @@ def parse_twix_header(header_string):
             "f0": frequency,
             "transform": transform,
             "te": te,
+            "tr": tr,
             "exam_date": exam_date,
             "exam_time": exam_time
             }
@@ -422,13 +426,13 @@ def anonymize_twix_header(header_string):
         The anonymized version of the header.
     """
 
-    patient_name = "(<ParamString.\"t?Patients?Name\">\s*\{\s*\")(.+)(\"\s*\}\n)"
-    patient_id = "(<ParamString.\"PatientID\">\s*\{\s*\")(.+)(\"\s*\}\n)"
-    patient_birthday = "(<ParamString.\"PatientBirthDay\">\s*\{\s*\")(.+)(\"\s*\}\n)"
-    patient_gender = "(<ParamLong.\"l?PatientSex\">\s*\{\s*)(\d+)(\s*\}\n)"
-    patient_age = "(<ParamDouble.\"flPatientAge\">\s*\{\s*<Precision> \d+\s*)(\d+\.\d*)(\s*\}\n)"
-    patient_weight = "(<ParamDouble.\"flUsedPatientWeight\">\s*\{\s*<Precision> \d+\s*)(\d+\.\d*)(\s*\}\n)"
-    patient_height = "(<ParamDouble.\"flPatientHeight\">\s*\{\s*<Unit> \"\[mm\]\"\s*<Precision> \d+\s*)(\d+\.\d*)(\s*\}\n)"
+    patient_name = r"(<ParamString.\"t?Patients?Name\">\s*\{\s*\")(.+)(\"\s*\}\n)"
+    patient_id = r"(<ParamString.\"PatientID\">\s*\{\s*\")(.+)(\"\s*\}\n)"
+    patient_birthday = r"(<ParamString.\"PatientBirthDay\">\s*\{\s*\")(.+)(\"\s*\}\n)"
+    patient_gender = r"(<ParamLong.\"l?PatientSex\">\s*\{\s*)(\d+)(\s*\}\n)"
+    patient_age = r"(<ParamDouble.\"flPatientAge\">\s*\{\s*<Precision> \d+\s*)(\d+\.\d*)(\s*\}\n)"
+    patient_weight = r"(<ParamDouble.\"flUsedPatientWeight\">\s*\{\s*<Precision> \d+\s*)(\d+\.\d*)(\s*\}\n)"
+    patient_height = r"(<ParamDouble.\"flPatientHeight\">\s*\{\s*<Unit> \"\[mm\]\"\s*<Precision> \d+\s*)(\d+\.\d*)(\s*\}\n)"
 
     header_string = re.sub(patient_name, lambda match: "".join(
         (match.group(1), ("x" * (len(match.group(2)))), match.group(3))),

--- a/suspect/mrsobjects.py
+++ b/suspect/mrsobjects.py
@@ -9,12 +9,13 @@ class MRSBase(suspect.base.ImageBase):
     time.
 
     """
-    def __new__(cls, input_array, dt, f0, te=30, ppm0=4.7, voxel_dimensions=(10, 10, 10), transform=None, metadata=None):
+    def __new__(cls, input_array, dt, f0, te=30, tr=-1, ppm0=4.7, voxel_dimensions=(10, 10, 10), transform=None, metadata=None):
         obj = super(MRSBase, cls).__new__(cls, input_array, transform)
         # add the new attributes to the created instance
         obj._dt = dt
         obj._f0 = f0
         obj._te = te
+        obj._tr = tr
         obj.ppm0 = ppm0
         obj.voxel_dimensions = voxel_dimensions
         obj.metadata = metadata
@@ -25,6 +26,7 @@ class MRSBase(suspect.base.ImageBase):
         self._dt = getattr(obj, 'dt', None)
         self._f0 = getattr(obj, 'f0', None)
         self._te = getattr(obj, 'te', 30)
+        self._tr = getattr(obj, 'tr', -1)
         self.ppm0 = getattr(obj, 'ppm0', None)
         self.transform = getattr(obj, 'transform', None)
         self.metadata = getattr(obj, 'metadata', None)
@@ -59,6 +61,7 @@ class MRSBase(suspect.base.ImageBase):
         cast_array._dt = self.dt
         cast_array._f0 = self.f0
         cast_array._te = self.te
+        cast_array._tr = self.tr
         cast_array.ppm0 = self.ppm0
         cast_array.voxel_dimensions = self.voxel_dimensions
         cast_array.transform = self.transform
@@ -101,6 +104,13 @@ class MRSBase(suspect.base.ImageBase):
 
         """
         return self._te
+
+    @property
+    def tr(self):
+        """The repetition time of the sequence in ms.
+
+        """
+        return self._tr
 
     @property
     def f0(self):

--- a/tests/test_mrs/test_ima.py
+++ b/tests/test_mrs/test_ima.py
@@ -8,6 +8,8 @@ import suspect.io.siemens
 def test_svs_30():
     data = suspect.io.siemens.load_siemens_dicom("tests/test_data/siemens/SVS_30.IMA")
     assert data.shape == (1024,)
+    assert data.te == 30
+    assert data.tr == 2000
 
 
 # def test_svs_30():

--- a/tests/test_mrs/test_rda.py
+++ b/tests/test_mrs/test_rda.py
@@ -13,6 +13,8 @@ def test_twix_nofile():
 def test_svs_file():
     data = suspect.io.load_rda("tests/test_data/siemens/SVS_30.rda")
     assert data.shape == (1024,)
+    assert data.tr == 2000
+    assert data.te == 30
 
     # transform of centre of voxel is same as position
     voxel_position = data.to_scanner(0, 0, 0)

--- a/tests/test_mrs/test_twix.py
+++ b/tests/test_mrs/test_twix.py
@@ -15,6 +15,7 @@ def test_veriofile():
     assert data.np == 2048
     assert data.dt == 2.5e-4
     assert data.te == 30.0
+    assert data.tr == 2000
     numpy.testing.assert_almost_equal(data.f0, 123.261716)
     numpy.testing.assert_allclose(data.transform, numpy.array(
         [[-20, 0, 0, 4.917676],


### PR DESCRIPTION
This commit adds the TR property to MRSBase objects, read from the
various data formats supported. This is primarily intended to be
useful in calculating attenuation of water signals for absolute
quantification calculation.

Closes #135