### PR TITLE
#BUG error selecting scanner axes in oblong voxels

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :bug:`139` fixed an issue where axial/sagittal/coronal vectors could be calculated incorrectly
 * :release:`0.4.1 <24/05/20>`
 * :feature:`137` added functions to support absolute quantification
 * :feature:`135` added TR parameter to MRSBase objects

--- a/suspect/base.py
+++ b/suspect/base.py
@@ -131,7 +131,8 @@ class ImageBase(np.ndarray):
 
     @requires_transform
     def _closest_axis(self, target_axis):
-        overlap = np.abs(np.dot(target_axis, self.transform[:3, :3]))
+        voxel_axes = self.transform[:3, :3] / self.voxel_size
+        overlap = np.abs(np.dot(target_axis, voxel_axes))
         return self.transform[:3, np.argmax(overlap)]
 
     @property

--- a/tests/test_mrs/test_base.py
+++ b/tests/test_mrs/test_base.py
@@ -70,6 +70,17 @@ def test_find_axes_reversed():
     np.testing.assert_equal(base.sagittal_vector, -base.row_vector)
 
 
+def test_find_axes_oblong():
+    transform = _transforms.transformation_matrix([2, 1, 0],
+                                                  [-1, 2, 0],
+                                                  [0, 0, 0],
+                                                  [40, 4, 1])
+    base = suspect.base.ImageBase(np.zeros(1), transform=transform)
+    np.testing.assert_equal(base.axial_vector, base.slice_vector)
+    np.testing.assert_equal(base.coronal_vector, base.col_vector)
+    np.testing.assert_equal(base.sagittal_vector, base.row_vector)
+
+
 def test_centre():
     transform = _transforms.transformation_matrix([1, 0, 0],
                                                   [0, 1, 0],


### PR DESCRIPTION
The `_closest_axis()` function was not normalising the voxel direction
vectors so for an oblong and oblique voxel the dot product with a
reference vector (like (0, 1, 0)) could be larger for the long axis
than the more parallel one.