### PR TITLE
#ENH Anonymization for TWIX VD/VE files

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :enh:`11` added anonymisation of twix VD/VE files
 * :bug:`139` fixed an issue where axial/sagittal/coronal vectors could be calculated incorrectly
 * :release:`0.4.1 <24/05/20>`
 * :feature:`137` added functions to support absolute quantification


### PR DESCRIPTION
This commit adds code to anonymize Siemens TWIX files of VD and VE
version.

Fixes #11