### PR TITLE
#BUG143 incorrect data shape in some Siemens .IMA files

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :bug:`143` changed .IMA loading to handle cases where data shape is calculated incorrectly
 * :enh:`11` added anonymisation of twix VD/VE files
 * :bug:`139` fixed an issue where axial/sagittal/coronal vectors could be calculated incorrectly
 * :release:`0.4.1 <24/05/20>`


### PR DESCRIPTION
This fix is to address the problem that for some Siemens .IMA files the
calculated data shape does not match the size of the accompanying data,
resulting in an Exception. The change means that in this situation the
data shape is adjusted to use the data size, rather than the (multi-
dimensional) shape calculated from the header info.

fixes #143