### PR TITLE
Added regex for extracting metadata on VIDA data

### DIFF
--- a/suspect/io/twix.py
+++ b/suspect/io/twix.py
@@ -209,24 +209,28 @@ def parse_twix_header(header_string):
     in_plane_rot_matches = [
         r"<ParamDouble\.\"VoI_InPlaneRotAngle\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
         r"<ParamDouble\.\"VoiInPlaneRot\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
+        r"<ParamDouble\.\"VoiInPlaneRot\">\s*{\s*(-?[0-9\.]+)?\s*}",
         r"<ParamDouble\.\"VoI_InPlaneRotAngle\">\s*{\s*(-?[0-9\.]+)?\s*}"
     ]
     normal_sag_matches = [
         r"sSpecPara\.sVoI\.sNormal\.dSag\s*=\s*(-?[[0-9]*[.]?[0-9]*]{0,})\s*$",
         r"<ParamDouble\.\"VoI_Normal_Sag\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
         r"<ParamDouble\.\"VoiNormalSag\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
+        r"<ParamDouble\.\"VoiNormalSag\">\s*{\s*(-?[0-9\.]+)?\s*}",
         r"<ParamDouble\.\"VoI_Normal_Sag\">\s*{\s*(-?[0-9\.]+)?\s*}"
     ]
     normal_cor_matches = [
         r"sSpecPara\.sVoI\.sNormal\.dCor\s*=\s*(-?[[0-9]*[.]?[0-9]*]{0,})\s*$",
         r"<ParamDouble\.\"VoI_Normal_Cor\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
         r"<ParamDouble\.\"VoiNormalCor\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
+        r"<ParamDouble\.\"VoiNormalCor\">\s*{\s*(-?[0-9\.]+)?\s*}",
         r"<ParamDouble\.\"VoI_Normal_Cor\">\s*{\s*(-?[0-9\.]+)?\s*}"
     ]
     normal_tra_matches = [
         r"sSpecPara\.sVoI\.sNormal\.dTra\s*=\s*(-?[[0-9]*[.]?[0-9]*]{0,})\s*$",
         r"<ParamDouble\.\"VoI_Normal_Tra\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
         r"<ParamDouble\.\"VoiNormalTra\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
+        r"<ParamDouble\.\"VoiNormalTra\">\s*{\s*(-?[0-9\.]+)?\s*}",
         r"<ParamDouble\.\"VoI_Normal_Tra\">\s*{\s*(-?[0-9\.]+)?\s*}"
     ]
     in_plane_rot = get_meta_regex(in_plane_rot_matches, header_string, default=0)

--- a/suspect/io/twix.py
+++ b/suspect/io/twix.py
@@ -189,16 +189,19 @@ def parse_twix_header(header_string):
     pos_sag_matches = [
         r"sSpecPara\.sVoI\.sPosition\.dSag\s*=\s*(-?[[0-9]*[.]?[0-9]*]{0,})\s*",
         r"<ParamDouble\.\"VoI_Position_Sag\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
+        r"<ParamDouble\.\"VoiPositionSag\">\s*{\s*(-?[0-9\.]+)?\s*}",
         r"<ParamDouble\.\"VoI_Position_Sag\">\s*{\s*(-?[0-9\.]+)?\s*}"
     ]
     pos_cor_matches = [
         r"sSpecPara\.sVoI\.sPosition\.dCor\s*=\s*(-?[[0-9]*[.]?[0-9]*]{0,})\s*",
         r"<ParamDouble\.\"VoI_Position_Cor\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
+        r"<ParamDouble\.\"VoiPositionCor\">\s*{\s*(-?[0-9\.]+)?\s*}",
         r"<ParamDouble\.\"VoI_Position_Cor\">\s*{\s*(-?[0-9\.]+)?\s*}"
     ]
     pos_tra_matches = [
         r"sSpecPara\.sVoI\.sPosition\.dTra\s*=\s*(-?[[0-9]*[.]?[0-9]*]{0,})\s*",
         r"<ParamDouble\.\"VoI_Position_Tra\">  { <Precision> \d+(  -?[0-9\.]+)?  }",
+        r"<ParamDouble\.\"VoiPositionTra\">\s*{\s*(-?[0-9\.]+)?\s*}",
         r"<ParamDouble\.\"VoI_Position_Tra\">\s*{\s*(-?[0-9\.]+)?\s*}"
     ]
     pos_sag = get_meta_regex(pos_sag_matches, header_string, default=0)


### PR DESCRIPTION
I found that in one of our VIDA scan, `VoiNormal` and `VoiInPlaneRot` only exist in the added regex, which essentially one of the existing regex without `<Precision>` information. 

In my case, the `VoiNormalSag`, `VoiNormalCor`, and `VoiInPlaneRot` are empty, while the `VoiNormalTra` is 1 and existed in other places (e.g. `sSpecPara.sVoI.sNormal.dTra`) with the same value.

Without adding this, it will raise `KeyError` since the patterns are not found.
https://github.com/openmrslab/suspect/blob/b35dbe684fd8edea4e9700dd3b8992401521d689/suspect/io/twix.py#L123