### PR TITLE
read_file -> pydicom.dcmread

### DIFF
--- a/suspect/image/_image.py
+++ b/suspect/image/_image.py
@@ -25,7 +25,7 @@ def load_dicom_volume(filename):
     """
     _, file_ext = os.path.splitext(filename)
     # load the supplied file and get the UID of the series
-    ds = pydicom.read_file(filename)
+    ds = pydicom.dcmread(filename)
     seriesUID = ds.SeriesInstanceUID
 
     # get the position of the image
@@ -49,7 +49,7 @@ def load_dicom_volume(filename):
         if name.endswith(file_ext): # name.lower().endswith(".ima") or name.lower().endswith(".dcm"):
             new_dicom_name = os.path.join(folder, name)
             try:
-                new_ds = pydicom.read_file(new_dicom_name)
+                new_ds = pydicom.dcmread(new_dicom_name)
             except pydicom.errors.InvalidDicomError as e:
                 continue
 

--- a/suspect/io/dicom.py
+++ b/suspect/io/dicom.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from ._common import complex_array_from_iter
 
-import pydicom.dicomio
+import pydicom
 import pydicom.tag
 
 

--- a/suspect/io/dicom.py
+++ b/suspect/io/dicom.py
@@ -22,7 +22,7 @@ def load_dicom(filename):
     MRSData
         The loaded data from the file
     """
-    dataset = pydicom.dicomio.read_file(filename)
+    dataset = pydicom.dcmread(filename)
 
     # format for metadata dictionary elements:
     #   {'key': [[dicom_tag], required], ...}

--- a/suspect/io/siemens.py
+++ b/suspect/io/siemens.py
@@ -105,7 +105,7 @@ def load_siemens_dicom(filename):
     # the .IMA format is a DICOM standard, unfortunately most of the information is contained inside a private and very
     # complicated header with its own data storage format, we have to get that information out along with the data
     # start by reading in the DICOM file completely
-    dataset = pydicom.dicomio.read_file(filename)
+    dataset = pydicom.dcmread(filename)
     # now look through the tags (0029, 00xx) to work out which xx refers to the csa header
     # xx seems to start at 10 for Siemens
     xx = 0x0010
@@ -210,7 +210,7 @@ def load_siemens_dicom(filename):
 #     :param anonymized_filename:
 #     :return:
 #     """
-#     dataset = pydicom.dicomio.read_file(filename)
+#     dataset = pydicom.dcmread(filename)
 #     print(dataset.PatientName)
 #     xx = 0x0010
 #     header_index = 0

--- a/suspect/io/siemens.py
+++ b/suspect/io/siemens.py
@@ -1,5 +1,5 @@
 import pydicom.tag
-import pydicom.dicomio
+import pydicom
 import numpy
 import struct
 import warnings


### PR DESCRIPTION
`pydicom.dicomio.read_file` and `pydicom.read_file` are removed in pydicom v3.0.0 and it is suggested to use `pydicom.dcmread` instead. 

See release notes: https://pydicom.github.io/pydicom/stable/release_notes/index.html#version-3-0-0

