### PR TITLE
More general way to loop over dicom group

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v5
         with:
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9, 3.10.0, 3.11, 3.12]
+        python-version: [3.9, 3.10, 3.11, 3.12]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/suspect/io/siemens.py
+++ b/suspect/io/siemens.py
@@ -106,14 +106,12 @@ def load_siemens_dicom(filename):
     # complicated header with its own data storage format, we have to get that information out along with the data
     # start by reading in the DICOM file completely
     dataset = pydicom.dcmread(filename)
-    # now look through the tags (0029, 00xx) to work out which xx refers to the csa header
-    # xx seems to start at 10 for Siemens
-    xx = 0x0010
+    # now loop through the available element in group (0029) to work out the element 
+    # number of the csa header
     header_index = 0
-    while (0x0029, xx) in dataset:
-        if dataset[0x0029, xx].value == "SIEMENS CSA HEADER":
-            header_index = xx
-        xx += 1
+    for e in dataset.group_dataset(0x0029).iterall():
+        if e.value == "SIEMENS CSA HEADER":
+            header_index = e.tag.element
     # check that we have found the header
     if header_index == 0:
         raise KeyError("Could not find header index")
@@ -131,14 +129,12 @@ def load_siemens_dicom(filename):
                   csa_header["DataPointColumns"],
                   )
 
-    # now look through the tags (0029, 00xx) to work out which xx refers to the csa header
-    # xx seems to start at 10 for Siemens
-    xx = 0x0010
+    # now loop through the available element in group (7fe1) to work out the element
+    # number of the data index
     data_index = 0
-    while (0x7fe1, xx) in dataset:
-        if dataset[0x7fe1, xx].value == "SIEMENS CSA NON-IMAGE":
-            data_index = xx
-        xx += 1
+    for e in dataset.group_dataset(0x7fe1).iterall():
+        if e.value == "SIEMENS CSA NON-IMAGE":
+            data_index = e.tag.element
     # check that we have found the data
     if data_index == 0:
         raise KeyError("Could not find data index")


### PR DESCRIPTION
Rather than setting a starting point and incrementing by 1 to find CSA header and CSA data, user `dataset.group_dataset(group_number).iterall()`. 

The old method would fail if DICOM anonymisation stripped off the first expected element number, e.g. tag (0029,0010). 