### PR TITLE
`suspect.io.load_twix()` to accept binary stream input

### DIFF
--- a/suspect/io/dicom.py
+++ b/suspect/io/dicom.py
@@ -56,7 +56,7 @@ def load_dicom(filename):
 
     # versions of pydicom >2.0.0 require explicit conversion from bytestring to list
     if type(dataset[0x5600, 0x0020].value) == bytes:
-        data_iter = iter(np.fromstring(dataset[0x5600, 0x0020].value, dtype=np.float32))
+        data_iter = iter(np.frombuffer(dataset[0x5600, 0x0020].value, dtype=np.float32))
 
     elif type(dataset[0x5600, 0x0020].value) == list:
         data_iter = iter(dataset[0x5600, 0x0020].value)

--- a/suspect/io/twix.py
+++ b/suspect/io/twix.py
@@ -4,6 +4,7 @@ import struct
 import numpy
 #import quaternion
 import re
+import io
 
 # This file largely relies on information from Siemens regarding the structure
 # of the TWIX file formats. Most of the parameters that are read use the same
@@ -97,10 +98,14 @@ def get_meta_regex(regex_list, header_string, convert=1, default=None):
 
     Parameters
     ----------
-    regex_list : List of regex string
-    header_string : TWIX header string
-    convert : Unit convertion, if value is number. Defaults to 1 (means no convertion)
-    default : Default value if match found, but value is empty. Defaults to None.
+    regex_list : list
+        List of regex string
+    header_string : string
+        TWIX header string
+    convert : int, optional
+        Unit convertion, if value is number. Defaults to 1 (means no convertion)
+    default
+        Default value if match found, but value is empty. Defaults to None.
 
     Returns
     -------
@@ -502,10 +507,24 @@ def load_twix_vd(fin, builder):
         # move the file pointer to the start of the next scan
         fin.seek(initial_position + DMA_length)
 
+def load_twix(filename, buffering=io.DEFAULT_BUFFER_SIZE):
+    """
+    Load TWIX data. 
 
-def load_twix(filename):
-    with open(filename, 'rb') as fin:
+    Parameters
+    ----------
+    filename : str
+        File path of TWIX file
+    buffering : int, optional
+        Buffer size to be passed to `open()` function. Defaults to 
+        `io.DEFAULT_BUFFER_SIZE`
 
+    Returns
+    -------
+    suspect.MRSData
+
+    """
+    with open(filename, 'rb', buffering=buffering) as fin:
         # we can tell the type of file from the first two uints in the header
         first_uint, second_uint = struct.unpack("II", fin.read(8))
 

--- a/tests/test_mrs/test_twix.py
+++ b/tests/test_mrs/test_twix.py
@@ -39,6 +39,10 @@ def test_veriofile():
          [0, 0, 0, 1]]
     ))
 
+    # Test loading via file-like object and ensure same result
+    with open("tests/test_data/siemens/twix_vd.dat", "rb") as f:
+        data_from_binary_stream = suspect.io.load_twix(f)
+        assert numpy.all(data == data_from_binary_stream)
 #def test_skyra():
 #    data = suspect.io.load_twix("tests/test_data/twix_vd_csi.dat")
 #    assert data.np == 2048


### PR DESCRIPTION
To mitigate the slow reading for network drive access as reported in #182, `load_twix()` now supports handling binary stream. By doing this, user can increase the buffer size in the `open()` function. For example:
```python
In [4]: with open("/Users/darren/tmp/test-copy.dat", 'rb', buffering=1024*1024) as f:
   ...:     test_twix = suspect.io.load_twix(f)
   ...:
```

Per my testing, increasing the buffer size significantly improves the read speed. Using the same example in the issue, the total time is down to ~64s when increasing the buffer to 1MiB(vs ~1174s when using `io.DEFAULT_BUFFER_SIZE` , which is 8KiB in my environment).

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    14985   64.459    0.004   64.459    0.004 {method 'read' of '_io.BufferedReader' objects} # Here
  8261568    2.266    0.000    2.266    0.000 <string>:61(<genexpr>)
        1    1.427    1.427    1.427    1.427 {built-in method _io.open}
     4032    1.125    0.000    3.389    0.001 {built-in method numpy.fromiter}
    14984    0.307    0.000    0.307    0.000 {built-in method _struct.unpack}
```

Also:
* `np.fromstring()` to `np.frombuffer()`.
* Fixed docstring format.

Closes #182 